### PR TITLE
feat: Add option UpstreamHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Added workaround for CSRF cookie](https://github.com/keboola/go-oauth2-proxy/commit/5486c9884b2953ba1a2d4efd0c89f527953104d1)
 - [Added option to configure upstream transport](https://github.com/keboola/go-oauth2-proxy/commit/8bde35a277a8548e12e9ad01f0658da22cbf04b6)
 - [Added argument for custom error handler](https://github.com/keboola/go-oauth2-proxy/commit/f9b5f906a4f40da25437425cc4e4b5a932ca2f36) 
+- [Added option `UpstreamHandler`](https://github.com/keboola/go-oauth2-proxy/commit/2b0c2a99d50ba80b68ffba8175ebc3b9311f6496)
 
 ## Fork maintenance
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -158,9 +158,17 @@ func NewOAuthProxyWithPageWriter(opts *options.Options, validator func(string) b
 		}
 	}
 
-	upstreamProxy, err := upstream.NewProxy(opts.UpstreamServers, opts.GetSignatureData(), pageWriter)
-	if err != nil {
-		return nil, fmt.Errorf("error initialising upstream proxy: %v", err)
+	var upstreamProxy http.Handler
+	if opts.UpstreamHandler != nil {
+		upstreamProxy = opts.UpstreamHandler
+		if len(opts.UpstreamServers.Upstreams) != 0 {
+			return nil, errors.New(`UpstreamHandler and UpstreamServers configuration options are not compatible`)
+		}
+	} else {
+		upstreamProxy, err = upstream.NewProxy(opts.UpstreamServers, opts.GetSignatureData(), pageWriter)
+		if err != nil {
+			return nil, fmt.Errorf("error initialising upstream proxy: %v", err)
+		}
 	}
 
 	upstreamProxy = opts.UpstreamChain.Then(upstreamProxy)

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"crypto"
+	"net/http"
 	"net/url"
 
 	"github.com/justinas/alice"
@@ -43,6 +44,7 @@ type Options struct {
 
 	// Not used in the legacy config, name not allowed to match an external key (upstreams)
 	// TODO(JoelSpeed): Rename when legacy config is removed
+	UpstreamHandler http.Handler   `cfg:",internal"`
 	UpstreamServers UpstreamConfig `cfg:",internal"`
 	UpstreamChain   alice.Chain    `cfg:",internal"`
 


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-541

Changes:
- Added option `UpstreamHandler`, to use a custom proxy `http.Handler`.
  - So we can use the same underlying `http.Handler` for public and authorized requests.
    - It simplifies code and testing.
